### PR TITLE
feat: include logger

### DIFF
--- a/include/logger.h
+++ b/include/logger.h
@@ -1,0 +1,25 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <stdio.h>
+#include <time.h>
+
+typedef enum
+{
+    LOG_DEBUG,
+    LOG_INFO,
+    LOG_WARN,
+    LOG_ERROR
+} log_level_t;
+
+void log_message(log_level_t level, const char *file, int line, const char *fmt, ...);
+
+// Configure log level
+void set_log_level(log_level_t level);
+
+#define LOG_DEBUG(fmt, ...) log_message(LOG_DEBUG, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) log_message(LOG_INFO, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) log_message(LOG_WARN, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+#define LOG_ERROR(fmt, ...) log_message(LOG_ERROR, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+
+#endif // LOGGER_H

--- a/src/logger.c
+++ b/src/logger.c
@@ -1,0 +1,61 @@
+#include "logger.h"
+#include <stdarg.h>
+#include <string.h>
+
+static log_level_t current_level = LOG_INFO;
+
+static const char *level_to_str(log_level_t level)
+{
+    switch (level)
+    {
+    case LOG_DEBUG:
+        return "DEBUG";
+    case LOG_INFO:
+        return "INFO";
+    case LOG_WARN:
+        return "WARN";
+    case LOG_ERROR:
+        return "ERROR";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+void set_log_level(log_level_t level)
+{
+    current_level = level;
+}
+
+// Get ISO8601 timestamp
+static void current_timestap(char *buffer, size_t size)
+{
+    time_t now = time(NULL);
+    const struct tm *t = gmtime(&now); // UTC
+    strftime(buffer, size, "%Y-%m-%dT%H:%M:%SZ", t);
+}
+
+void log_message(log_level_t level, const char *file, int line, const char *fmt, ...)
+{
+    if (level < current_level)
+    {
+        return; // Skip logs below current level
+    }
+
+    char timestamp[32];
+    current_timestap(timestamp, sizeof(timestamp));
+
+    char message[1024];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(message, sizeof(message), fmt, args);
+    va_end(args);
+
+    FILE *out = (level == LOG_WARN || level == LOG_ERROR) ? stderr : stdout;
+
+    fprintf(out,
+            "{ \"timestamp\": \"%s\", \"level\": \"%s\", \"file\": \"%s\", \"line\": %d, "
+            "\"message\": \"%s\" }\n",
+            timestamp, level_to_str(level), file, line, message);
+
+    fflush(out);
+}

--- a/tests/test_logger.c
+++ b/tests/test_logger.c
@@ -1,0 +1,119 @@
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "logger.h"
+
+#define TMP_STDOUT "test_stdout.log"
+#define TMP_STDERR "test_stderr.log"
+
+// Helper: reset log files and redirect streams
+static void redirect_streams(void)
+{
+    if (freopen(TMP_STDOUT, "w", stdout) == NULL)
+    {
+        perror("freopen stdout failed");
+    }
+    if (freopen(TMP_STDERR, "w", stderr) == NULL)
+    {
+        perror("freopen stderr failed");
+    }
+    fflush(stdout);
+    fflush(stderr);
+}
+
+// Helper: read file content into string
+static char *read_file(const char *path)
+{
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return NULL;
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    rewind(f);
+
+    char *buf = malloc(size + 1);
+    fread(buf, 1, size, f);
+    buf[size] = '\0';
+    fclose(f);
+    return buf;
+}
+
+// --- Tests ---
+
+START_TEST(test_info_log_goes_to_stdout)
+{
+    redirect_streams();
+    set_log_level(LOG_INFO);
+
+    LOG_INFO("Service started");
+
+    fflush(stdout);
+    char *out = read_file(TMP_STDOUT);
+    ck_assert_msg(out != NULL, "stdout file missing");
+    ck_assert_msg(strstr(out, "\"level\": \"INFO\"") != NULL, "INFO log missing in stdout");
+    free(out);
+
+    char *err = read_file(TMP_STDERR);
+    ck_assert_msg(err != NULL, "stderr file missing");
+    ck_assert_int_eq(strlen(err), 0); // no errors expected
+    free(err);
+}
+END_TEST
+
+START_TEST(test_error_log_goes_to_stderr)
+{
+    redirect_streams();
+    set_log_level(LOG_DEBUG);
+
+    LOG_ERROR("Something failed");
+
+    fflush(stderr);
+    char *err = read_file(TMP_STDERR);
+    ck_assert_msg(err != NULL, "stderr file missing");
+    ck_assert_msg(strstr(err, "\"level\": \"ERROR\"") != NULL, "ERROR log missing in stderr");
+    free(err);
+
+    char *out = read_file(TMP_STDOUT);
+    ck_assert_msg(out != NULL, "stdout file missing");
+    ck_assert_int_eq(strlen(out), 0); // nothing in stdout
+    free(out);
+}
+END_TEST
+
+START_TEST(test_log_level_filtering)
+{
+    redirect_streams();
+    set_log_level(LOG_WARN);
+
+    LOG_DEBUG("Debug msg should be hidden");
+    LOG_INFO("Info msg should be hidden");
+    LOG_WARN("This is a warning");
+
+    fflush(stdout);
+    fflush(stderr);
+
+    char *out = read_file(TMP_STDOUT);
+    ck_assert_msg(out != NULL, "stdout file missing");
+    ck_assert_int_eq(strlen(out), 0); // no debug/info logs
+    free(out);
+
+    char *err = read_file(TMP_STDERR);
+    ck_assert_msg(err != NULL, "stderr file missing");
+    ck_assert_msg(strstr(err, "\"level\": \"WARN\"") != NULL, "WARN log missing in stderr");
+    free(err);
+}
+END_TEST
+
+Suite *logger_suite(void)
+{
+    Suite *s = suite_create("Logger");
+    TCase *tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_info_log_goes_to_stdout);
+    tcase_add_test(tc_core, test_error_log_goes_to_stderr);
+    tcase_add_test(tc_core, test_log_level_filtering);
+
+    suite_add_tcase(s, tc_core);
+    return s;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 Suite *utils_suite(void);
+Suite *logger_suite(void);
 
 int main(void)
 {
@@ -9,6 +10,8 @@ int main(void)
     SRunner *sr;
 
     sr = srunner_create(utils_suite());
+    srunner_add_suite(sr, logger_suite());
+
     srunner_run_all(sr, CK_NORMAL);
     number_failed = srunner_ntests_failed(sr);
     srunner_free(sr);


### PR DESCRIPTION
This pull request introduces a new logging module to the project, providing structured logging with configurable log levels and output streams. It includes both implementation and comprehensive unit tests to ensure correct behavior. The most important changes are grouped below:

**Logging Module Implementation:**

* Added new logging interface in `logger.h`, defining log levels, log macros, and configuration for log level filtering.
* Implemented `logger.c` with functions for logging messages in JSON format, including timestamp, log level, source file, and line number. Output is directed to `stdout` for info/debug and `stderr` for warn/error, with log level filtering.

**Testing and Integration:**

* Created `test_logger.c` with unit tests for logging output, log level filtering, and correct stream redirection, ensuring reliable behavior of the logger.
* Integrated the logger test suite into the main test runner by updating `test_main.c` to include `logger_suite`.add new module to allow the creation of log entries in an structured format using json